### PR TITLE
Fix example in usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ export default class HttpExceptionHandler extends ExceptionHandler {
 
   async report(error: unknown, ctx: HttpContext) {
     if (this.shouldReport(error as any)) {
-      ctx.slack.sendException(error)
+      ctx?.slack?.sendException(error)
     }
 
     return super.report(error, ctx)


### PR DESCRIPTION
Fix exception handler to handle optional slack context.

It could be the case the error did not occur by a web request where the middleware is not attached (so there might be no slack context available). This caused my web app to crash initially.